### PR TITLE
fix grail valueType wrong

### DIFF
--- a/astral-town/content/config/astral/town/buildings.json
+++ b/astral-town/content/config/astral/town/buildings.json
@@ -288,28 +288,28 @@
 							"type": "MAGIC_SCHOOL_SKILL",
 							"subtype": "air",
 							"val": 2,
-							"valueType": "INDEPENDENT_MIN",
+							"valueType": "INDEPENDENT_MAX",
 							"propagator": "PLAYER_PROPAGATOR" 
 						},
 						{
 							"type": "MAGIC_SCHOOL_SKILL",
 							"subtype": "earth",
 							"val": 2,
-							"valueType": "INDEPENDENT_MIN",
+							"valueType": "INDEPENDENT_MAX",
 							"propagator": "PLAYER_PROPAGATOR" 
 						},
 						{
 							"type": "MAGIC_SCHOOL_SKILL",
 							"subtype": "fire",
 							"val": 2,
-							"valueType": "INDEPENDENT_MIN",
+							"valueType": "INDEPENDENT_MAX",
 							"propagator": "PLAYER_PROPAGATOR" 
 						},
 						{
 							"type": "MAGIC_SCHOOL_SKILL",
 							"subtype": "water",
 							"val": 2,
-							"valueType": "INDEPENDENT_MIN",
+							"valueType": "INDEPENDENT_MAX",
 							"propagator": "PLAYER_PROPAGATOR" 
 						}
 					],


### PR DESCRIPTION
Grail feature: All spells can be cast in advanced level at least.
should use INDEPENDENT_MAX instead of INDEPENDENT_MIN